### PR TITLE
rename variable name to prevent collision with nginx 1.12 builtin  var

### DIFF
--- a/ngx_x_rid_header_module.c
+++ b/ngx_x_rid_header_module.c
@@ -81,7 +81,7 @@ ngx_int_t ngx_x_rid_header_get_variable(ngx_http_request_t *r, ngx_http_variable
   return NGX_OK;
 }   
                                   
-static ngx_str_t  ngx_x_rid_header_variable_name = ngx_string("request_id");
+static ngx_str_t  ngx_x_rid_header_variable_name = ngx_string("request_uuid");
 
 static ngx_int_t ngx_x_rid_header_add_variables(ngx_conf_t *cf)
 {


### PR DESCRIPTION
nginx 1.12 does not start with this module built in. This is because the variable name conflicts with the new builtin $request_id variable in nginx: https://github.com/nginx/nginx/commit/f315b7a924fa2c0da69c21078c930391a424aeef